### PR TITLE
HUB-54:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+## [1.0.0] - 2018-11-14
+### Added
+- Added information into `changelog`.
+### Changed
+- Changed license type to the `MIT`.
+- Removed redundant class comments.
+- Increased minimal php version requirements to the `7.1`.
+### Removed
+- Removed `Enumer::getEnumBit()` method.
+### Fixed
+- Fixed `Enumer::normalize()` method to correct work with not string values.
+
+## [0.1.0] - 2018-10-04
+### Added
+- First release of this component.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Enumer
-============
+======
 
 Введение
 --------
@@ -34,17 +34,14 @@ $enumer = new Enumer($enumRegistry);
 // Нормализация значения
 $enumer->normalize(GenderEnum::class, 'male');
 
-//Получеие списка 
+// Получеие списка 
 $enumer->getList(GenderEnum::class);
 
-//Получеие списка с ключами 
+// Получеие списка с ключами 
 $enumer->getCombineList(GenderEnum::class);
-
-//Получение бита
-$enumer->getEnumBit(GenderEnum::class, GenderEnum::MALE);
 ```
 
 Лицензия
 --------
 
-![license](https://img.shields.io/badge/License-proprietary-red.svg?style=flat-square)
+[![license](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](./LICENSE)

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "description": "Provides possibility for enum",
     "type":        "library",
     "keywords":    ["unique-id", "enumer"],
-    "license":     "proprietary",
+    "license":     "MIT",
 
     "require": {
-        "php": "~7.0",
+        "php":          "~7.1",
         "ext-mbstring": "*"
     },
 

--- a/example/GenderEnum.php
+++ b/example/GenderEnum.php
@@ -1,10 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Wakeapp\Component\Enumer\Example;
 
-/**
- * Class GenderEnum
- */
 class GenderEnum
 {
     const MALE = 'Male';

--- a/src/EnumRegistry.php
+++ b/src/EnumRegistry.php
@@ -7,17 +7,19 @@ namespace Wakeapp\Component\Enumer;
 use ReflectionClass;
 use ReflectionException;
 use Wakeapp\Component\Enumer\Exception\EnumNotRegisteredException;
+use function array_change_key_case;
+use function array_combine;
+use function sprintf;
 
-/**
- * Class EnumRegistry
- */
 class EnumRegistry
 {
     const TYPE_ORIGINAL = 'Original';
     const TYPE_COMBINE = 'Combine';
     const TYPE_COMBINE_NORMALIZE = 'CombineNormalize';
 
-    /** @var array[] */
+    /**
+     * @var array[]
+     */
     private $enumList;
 
     /**
@@ -49,9 +51,7 @@ class EnumRegistry
         $enum = $this->enumList[$enumClass][$type] ?? null;
 
         if ($enum === null) {
-            throw new EnumNotRegisteredException(
-                sprintf('Enum "%s" not registered.', $enumClass)
-            );
+            throw new EnumNotRegisteredException(sprintf('Enum type "%s" not registered.', $enumClass));
         }
 
         return $enum;

--- a/src/Enumer.php
+++ b/src/Enumer.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Wakeapp\Component\Enumer;
 
-/**
- * Class Enumer
- */
+use function is_string;
+use function mb_strtolower;
+
 class Enumer
 {
     /**
@@ -44,42 +44,14 @@ class Enumer
 
     /**
      * @param string $enumClass
-     * @param string $value
+     * @param string|int|float|null $value
      * @param bool $isConvertToLowercase
      *
-     * @return int
-     */
-    public function getEnumBit(string $enumClass, string $value, bool $isConvertToLowercase = true): int
-    {
-        $enum = $this->enumRegistry->getEnum($enumClass, EnumRegistry::TYPE_COMBINE_NORMALIZE);
-
-        if ($isConvertToLowercase) {
-            $value = mb_strtolower($value);
-        }
-
-        $index = 0;
-
-        foreach (array_keys($enum) as $constant) {
-            if ($constant === $value) {
-                return 1 << $index;
-            }
-
-            $index++;
-        }
-
-        return 0;
-    }
-
-    /**
-     * @param string $enumClass
-     * @param string $value
-     * @param bool $isConvertToLowercase
-     *
-     * @return null|string
+     * @return string|null
      */
     public function normalize(string $enumClass, $value, bool $isConvertToLowercase = true): ?string
     {
-        if ($isConvertToLowercase) {
+        if ($isConvertToLowercase && is_string($value)) {
             $value = mb_strtolower($value);
         }
 

--- a/src/Exception/EnumNotRegisteredException.php
+++ b/src/Exception/EnumNotRegisteredException.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Wakeapp\Component\Enumer\Exception;
 
-/**
- * Class EnumNotRegisteredException
- */
 class EnumNotRegisteredException extends WakeappEnumerException
 {
 }

--- a/src/Exception/WakeappEnumerException.php
+++ b/src/Exception/WakeappEnumerException.php
@@ -6,9 +6,6 @@ namespace Wakeapp\Component\Enumer\Exception;
 
 use RuntimeException;
 
-/**
- * Class WakeappEnumerException
- */
 class WakeappEnumerException extends RuntimeException
 {
 }


### PR DESCRIPTION
- Added information into `changelog`.
- Removed redundant class comments.
- Changed license type to the `MIT`.
- Removed `Enumer::getEnumBit()` method.
- Increased minimal php version requirements to the `7.1`.
- Fixed `Enumer::normalize()` method to correct work with not string values.